### PR TITLE
Bandaid fix for Facebook new theme.

### DIFF
--- a/src/ffbeSync/ffbeSync.js
+++ b/src/ffbeSync/ffbeSync.js
@@ -27,7 +27,7 @@
             return;
         }
 
-        chrome.tabs.create({'url':'https://www.facebook.com'}, (tab) => {
+        chrome.tabs.create({'url':'https://m.facebook.com'}, (tab) => {
             facebookTabId = tab.id;
             chrome.runtime.sendMessage({
                 type:"facebookTabId",


### PR DESCRIPTION
Changed from https://www.facebook.com to https://m.facebook.com. The mobile site still uses the old variables. It is uncertain if it will continue to do so, but for now it should at least allow people using Facebook bindings to sync.