### PR TITLE
Facebook login temp fix

### DIFF
--- a/src/ffbeSync/ffbeSync.html
+++ b/src/ffbeSync/ffbeSync.html
@@ -130,6 +130,8 @@
     <div class="title">FFBE Data Exporter (Facebook/Google)</div>
     <button id="googleExport" class="btn btn-primary">Start Google based Export</button>
     <button id="facebookExport" class="btn btn-primary">Start Facebook based Export</button>
+
+
     <div id="status">
       <div id="facebookToken" class="text notStarted">Facebook Token: <span class="loading"><span class="dot"></span><span class="dot"></span><span class="dot"></span></span><span class="ok">OK</span><span class="error">ERROR</span><span class="errorMessage"></span></div>
       <div id="facebookId" class="text notStarted">Facebook User Id: <span class="loading"><span class="dot"></span><span class="dot"></span><span class="dot"></span></span><span class="ok">OK</span><span class="error">ERROR</span><span class="errorMessage"></span></div>
@@ -155,7 +157,14 @@
         <dt>If your FFBE account is linked to Facebook</dt>
         <dd>Click on "Start Facebook based Export". A new tab will open, on Facebook. Make sure you're logged in facebook, and that the facebook page finished loading. After some seconds, you should be able to download your data files (units, inventory and espers)</dd>
       </dl>
+      <div id="facebookId">
+        <p>If using FB, obtain your user ID manually. Refer to <a href="https://www.facebook.com/help/1397933243846983">here</a> on how to obtain it </p>
+        <label for="name">User ID</label>
+        <input type="text" id="userId" name="name" required
+           minlength="17" maxlength="17" size="20">
+      </div>
     </div>
+   
     <button id="reinit" class="btn btn-secondary hidden">Start again</button>
     <script src="lib/jquery.min.js"></script>
     <script src="ffbeSync.js"></script>

--- a/src/ffbeSync/ffbeSync.js
+++ b/src/ffbeSync/ffbeSync.js
@@ -8,7 +8,7 @@ new Facebook login flow has removed need for continueFacebookExport button
     var facebookTabId;
 
     document.getElementById('googleExport').addEventListener('click', () => {
-        
+
         if (!confirm("Are you sure you want to allow this extension to grab your Google auth token and login to the game servers as yourself? Press OK to Continue")) {
             return;
         }
@@ -27,23 +27,31 @@ new Facebook login flow has removed need for continueFacebookExport button
 
     });
 
-    
+
     document.getElementById('facebookExport').addEventListener('click', () => {
         if (!confirm("Are you sure you want to allow this extension to grab your Facebook auth token and login to the game servers as yourself? Press OK to Continue")) {
             return;
         }
-        
-            chrome.tabs.create({ 'url': 'https://m.facebook.com/login.php?skip_api_login=1&api_key=1238083776220999&signed_next=1&next=https%3A%2F%2Fm.facebook.com%2Fv3.3%2Fdialog%2Foauth%3Fredirect_uri%3Dfbconnect%253A%252F%252Fsuccess%26display%3Dtouch%26state%3D%257B%25220_auth_logger_id%2522%253A%2522792e45db-e19b-4aec-9efa-767011b65d81%2522%252C%25223_method%2522%253A%2522web_view%2522%257D%26scope%3Duser_friends%26response_type%3Dtoken%252Csigned_request%26default_audience%3Dfriends%26return_scopes%3Dtrue%26auth_type%3Drerequest%26client_id%3D1238083776220999%26ret%3Dlogin%26sdk%3Dandroid-4.40.0%26logger_id%3D792e45db-e19b-4aec-9efa-767011b65d81&cancel_url=fbconnect%3A%2F%2Fsuccess%3Ferror%3Daccess_denied%26error_code%3D200%26error_description%3DPermissions%2Berror%26error_reason%3Duser_denied%26state%3D%257B%25220_auth_logger_id%2522%253A%2522792e45db-e19b-4aec-9efa-767011b65d81%2522%252C%25223_method%2522%253A%2522web_view%2522%257D%26e2e%3D%257B%2522init%2522%253A1549652357497%257D&display=touch&locale=en_US&logger_id=792e45db-e19b-4aec-9efa-767011b65d81&_rdr' }, (tab) => {
+
+        var userId = document.getElementById("userId").value;
+
+        if (userId.length === 0)
+            return;
+        else
+            chrome.storage.local.set({ "userId": userId }, function () { });
+
+        chrome.tabs.create({ 'url': 'https://m.facebook.com/login.php?skip_api_login=1&api_key=1238083776220999&signed_next=1&next=https%3A%2F%2Fm.facebook.com%2Fv14.0%2Fdialog%2Foauth%3Fredirect_uri%3Dfbconnect%253A%252F%252Fsuccess%26display%3Dtouch%26state%3D%257B%25220_auth_logger_id%2522%253A%2522792e45db-e19b-4aec-9efa-767011b65d81%2522%252C%25223_method%2522%253A%2522web_view%2522%257D%26response_type%3Dtoken%252Csigned_request%26default_audience%3Dfriends%26return_scopes%3Dtrue%26auth_type%3Drerequest%26client_id%3D1238083776220999%26ret%3Dlogin%26sdk%3Dandroid-4.40.0%26logger_id%3D792e45db-e19b-4aec-9efa-767011b65d81&cancel_url=fbconnect%3A%2F%2Fsuccess%3Ferror%3Daccess_denied%26error_code%3D200%26error_description%3DPermissions%2Berror%26error_reason%3Duser_denied%26state%3D%257B%25220_auth_logger_id%2522%253A%2522792e45db-e19b-4aec-9efa-767011b65d81%2522%252C%25223_method%2522%253A%2522web_view%2522%257D%26e2e%3D%257B%2522init%2522%253A1549652357497%257D&display=touch&locale=en_US&logger_id=792e45db-e19b-4aec-9efa-767011b65d81&_rdr' }, (tab) => {
             facebookTabId = tab.id;
             chrome.runtime.sendMessage({
                 type: "facebookTabId",
-                data: facebookTabId
+                data: facebookTabId,
             });
         });
 
         $('#googleExport').addClass('hidden');
         $('#facebookExport').addClass('hidden');
         $('#how-to-use').addClass('hidden');
+        $('#facebookId').addClass('hidden');
         $('#reinit').removeClass('hidden');
     });
 
@@ -51,6 +59,7 @@ new Facebook login flow has removed need for continueFacebookExport button
         $('#googleExport').removeClass('hidden');
         $('#facebookExport').removeClass('hidden');
         $('#how-to-use').removeClass('hidden');
+        $('#facebookId').removeClass('hidden');
         $('#reinit').addClass('hidden');
         $('.started').addClass('notStarted').removeClass('started');
         $('.finished').addClass('notStarted').removeClass('finished');

--- a/src/ffbeSync/manifest.json
+++ b/src/ffbeSync/manifest.json
@@ -16,8 +16,8 @@
    "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApMPWtk6eX0Dd+H6fAoDoCUAnMhFJQdivhhAIK95VVeDosflMuOrHUWjWc0xU1T1iIsWrxA2xyfnuKQWzFWJSLVtkfPFGMpkjqOYyafyqITlEGEF7wxV0anpF0ZMImnVDZ4kdVHNir9t9Dp2bSkzTm8/sdk4sfI2yz4zJLhor1uWFbSBlOwaleo1GUtdkXAx5j2wljdDyUp0sZtDDTF7M3UJupeXaNDKkEFoLeJ55FujM2+lhDfoD02NqM9RMpp5vKrrPFCkjVSajLgpsPZzKTP+eNbu4KuPaNa0lwvVQwb+07b861R3JpILPg6SeBG9ui9lC+FaAQ+TbXVyRhbIt0QIDAQAB",
    "manifest_version": 2,
    "name": "FFBE Sync",
-   "permissions": [ "tabs", "webRequest", "webRequestBlocking", "https://*.facebook.com/*", "https://lapis340v-gndgr.gumi.sg/*", "https://android.googleapis.com/auth", "https://accounts.google.com/*" ],
+   "permissions": [ "storage", "tabs", "webRequest", "webRequestBlocking", "https://*.facebook.com/*", "https://lapis340v-gndgr.gumi.sg/*", "https://android.googleapis.com/auth", "https://accounts.google.com/*" ],
    "web_accessible_resources" : [ "ffbeSync.html", "ffbeSync.js" ],
    "update_url": "https://clients2.google.com/service/update2/crx",
-   "version": "2.5.11"
+   "version": "2.6.0"
 }


### PR DESCRIPTION
This PR handles two issues of FB Login

**- FB Login not working due to changes of the redirect URL upon confirming.**

Previously upon completion of login, the redirect URL was `https://m.facebook.com/v7.0/dialog/oauth/confirm/`  and this has been changed to `/oauth/read` instead of` /oauth/confirm.`  This new URL returned also returns a EVA string which I do not know the purpose of yet.

**- The `https://graph.facebook.com/v3.2/me?access_token="`  endpoint not returning the user id.**

The main reason during the time of the testing of the Facebook Graph API /me node was not returning the user id. During the time of testing and it is unusual behaviour. 

This fix is a temp fix where the user obtains the user ID manually via going [here](https://www.facebook.com/help/1397933243846983) and then merely inputting the value into the input box.  Obtaining the user id programmatically might require more troubleshooting.